### PR TITLE
Add distinct lists API with caching for scan users and statuses

### DIFF
--- a/packageintake/src/main/java/com/clevelanddx/packageintake/config/CacheConfig.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/config/CacheConfig.java
@@ -13,7 +13,7 @@ public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
         ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
-        cacheManager.setCacheNames(java.util.Arrays.asList("clients"));
+        cacheManager.setCacheNames(java.util.Arrays.asList("clients", "scanUsers", "statuses"));
         return cacheManager;
     }
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/controller/InboundShipmentController.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/controller/InboundShipmentController.java
@@ -302,4 +302,13 @@ public class InboundShipmentController {
         List<String> statuses = service.getDistinctStatuses();
         return statuses.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(statuses);
     }
+    
+    @PostMapping("/distinct/refresh-cache")
+    @Operation(summary = "Refresh distinct lists cache", 
+               description = "Manually refreshes the cache for distinct scan users and statuses. Use this when you know the data has changed.")
+    @ApiResponse(responseCode = "200", description = "Cache refreshed successfully")
+    public ResponseEntity<String> refreshDistinctListsCache() {
+        service.evictDistinctListsCache();
+        return ResponseEntity.ok("Cache refreshed successfully. Next requests will fetch fresh data from the database.");
+    }
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/controller/InboundShipmentController.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/controller/InboundShipmentController.java
@@ -282,4 +282,24 @@ public class InboundShipmentController {
             return ResponseEntity.badRequest().build();
         }
     }
+    
+    @GetMapping("/distinct/scan-users")
+    @Operation(summary = "Get all distinct scan users", 
+               description = "Returns a cached list of all unique scan users from the inbound shipments table")
+    @ApiResponse(responseCode = "200", description = "Successfully retrieved distinct scan users")
+    @ApiResponse(responseCode = "204", description = "No scan users found")
+    public ResponseEntity<List<String>> getDistinctScanUsers() {
+        List<String> scanUsers = service.getDistinctScanUsers();
+        return scanUsers.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(scanUsers);
+    }
+
+    @GetMapping("/distinct/statuses")
+    @Operation(summary = "Get all distinct statuses", 
+               description = "Returns a cached list of all unique statuses from the inbound shipments table")
+    @ApiResponse(responseCode = "200", description = "Successfully retrieved distinct statuses")
+    @ApiResponse(responseCode = "204", description = "No statuses found")
+    public ResponseEntity<List<String>> getDistinctStatuses() {
+        List<String> statuses = service.getDistinctStatuses();
+        return statuses.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(statuses);
+    }
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/repository/InboundShipmentRepository.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/repository/InboundShipmentRepository.java
@@ -154,4 +154,23 @@ public interface InboundShipmentRepository extends JpaRepository<InboundShipment
         @Param("lastUpdateDatetimeTo") LocalDate lastUpdateDatetimeTo,
         Pageable pageable
     );
+    
+    // Distinct query methods for caching
+    @Query(value = """
+        SELECT DISTINCT Scan_User 
+        FROM Inbound_Shipments 
+        WHERE Scan_User IS NOT NULL 
+        AND Scan_User <> ''
+        ORDER BY Scan_User
+        """, nativeQuery = true)
+    List<String> findDistinctScanUsers();
+    
+    @Query(value = """
+        SELECT DISTINCT Status 
+        FROM Inbound_Shipments 
+        WHERE Status IS NOT NULL 
+        AND Status <> ''
+        ORDER BY Status
+        """, nativeQuery = true)
+    List<String> findDistinctStatuses();
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentService.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentService.java
@@ -35,4 +35,8 @@ public interface InboundShipmentService {
     
     // Search method
     InboundShipmentSearchResponse searchShipments(InboundShipmentSearchRequest searchRequest);
+    
+    // Distinct list methods with caching
+    List<String> getDistinctScanUsers();
+    List<String> getDistinctStatuses();
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentService.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentService.java
@@ -39,4 +39,7 @@ public interface InboundShipmentService {
     // Distinct list methods with caching
     List<String> getDistinctScanUsers();
     List<String> getDistinctStatuses();
+    
+    // Cache management
+    void evictDistinctListsCache();
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentServiceImpl.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -241,5 +242,17 @@ public class InboundShipmentServiceImpl implements InboundShipmentService {
             .hasNext(page.hasNext())
             .hasPrevious(page.hasPrevious())
             .build();
+    }
+    
+    @Override
+    @Cacheable(value = "scanUsers", key = "'all'")
+    public List<String> getDistinctScanUsers() {
+        return repository.findDistinctScanUsers();
+    }
+
+    @Override
+    @Cacheable(value = "statuses", key = "'all'")
+    public List<String> getDistinctStatuses() {
+        return repository.findDistinctStatuses();
     }
 } 

--- a/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentServiceImpl.java
+++ b/packageintake/src/main/java/com/clevelanddx/packageintake/service/InboundShipmentServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 
 import java.time.LocalDateTime;
 import java.time.LocalDate;
@@ -254,5 +255,11 @@ public class InboundShipmentServiceImpl implements InboundShipmentService {
     @Cacheable(value = "statuses", key = "'all'")
     public List<String> getDistinctStatuses() {
         return repository.findDistinctStatuses();
+    }
+    
+    @CacheEvict(value = {"scanUsers", "statuses"}, allEntries = true)
+    public void evictDistinctListsCache() {
+        // This method will clear the cache for both scan users and statuses
+        // The @CacheEvict annotation handles the actual cache clearing
     }
 } 


### PR DESCRIPTION
## Summary
This PR adds two new API endpoints to retrieve distinct scan users and statuses from the inbound shipments table, with built-in caching for performance optimization.

## New Features
- **GET** `/api/inbound-shipments/distinct/scan-users` - Returns all distinct scan users
- **GET** `/api/inbound-shipments/distinct/statuses` - Returns all distinct statuses  
- **POST** `/api/inbound-shipments/distinct/refresh-cache` - Manually refresh cache

## Implementation Details
- Added distinct query methods to `InboundShipmentRepository`
- Implemented cached service methods using `@Cacheable` annotation
- Updated `CacheConfig` to include new cache names (`scanUsers`, `statuses`)
- Added REST endpoints with comprehensive OpenAPI documentation
- Included cache refresh functionality with `@CacheEvict`

## Performance Benefits
- Database queries only run once per cache lifecycle
- Subsequent requests return cached data instantly
- Reduces database load for frequently accessed lists
- Manual cache refresh when data changes

## Testing
- All endpoints include proper HTTP status codes (200/204)
- Comprehensive Swagger/OpenAPI documentation
- Cache eviction works correctly

## Files Changed
- `InboundShipmentRepository.java` - Added distinct query methods
- `InboundShipmentService.java` - Added service interface methods
- `InboundShipmentServiceImpl.java` - Added cached implementations
- `CacheConfig.java` - Updated cache configuration
- `InboundShipmentController.java` - Added REST endpoints