### PR TITLE
Add maintenance scripts and unique constraint (Tracking_Number, Client)

### DIFF
--- a/maintenance/backup-inbound-shipments.sql
+++ b/maintenance/backup-inbound-shipments.sql
@@ -1,0 +1,79 @@
+-- Backup Inbound_Shipments to a backup table (same schema as of migrations V2–V8).
+-- Backup table has no foreign keys or IDENTITY so it can be populated from a SELECT.
+-- Run as needed; drop the backup table first if you want to replace a previous backup.
+
+SET NOCOUNT ON;
+
+-- Drop existing backup table if it exists (SQL Server 2016+)
+IF OBJECT_ID(N'dbo.Inbound_Shipments_Backup', N'U') IS NOT NULL
+    DROP TABLE dbo.Inbound_Shipments_Backup;
+
+-- Create backup table: same columns as Inbound_Shipments, no FKs, Row_ID not IDENTITY
+CREATE TABLE dbo.Inbound_Shipments_Backup (
+    Row_ID                BIGINT          NOT NULL,
+    Client                NVARCHAR(MAX)   NULL,
+    Tracking_Number       NVARCHAR(MAX)   NULL,
+    Status                NVARCHAR(MAX)   NULL,
+    Email_ID              NVARCHAR(MAX)   NULL,
+    Order_Number          NVARCHAR(MAX)   NULL,
+    Ship_Date             DATE            NULL,
+    Lab                   NVARCHAR(MAX)   NULL,
+    Weight                NVARCHAR(MAX)   NULL,
+    Number_Of_Samples     NVARCHAR(MAX)   NULL,
+    Pickup_Time           NVARCHAR(MAX)   NULL,
+    Pickup_Time_2         NVARCHAR(MAX)   NULL,
+    Email_Receive_Datetime DATETIME       NULL,
+    Last_Update_Datetime  DATETIME        NULL,
+    Scan_Time             DATETIME        NULL,
+    Client_ID             BIGINT          NULL,
+    Scan_User             NVARCHAR(MAX)   NULL,
+    Scanned_Number        NVARCHAR(255)   NULL,
+    Shipment_Type         BIGINT          NULL,
+    CONSTRAINT PK_Inbound_Shipments_Backup PRIMARY KEY (Row_ID)
+);
+
+-- Copy all rows from Inbound_Shipments
+INSERT INTO dbo.Inbound_Shipments_Backup (
+    Row_ID,
+    Client,
+    Tracking_Number,
+    Status,
+    Email_ID,
+    Order_Number,
+    Ship_Date,
+    Lab,
+    Weight,
+    Number_Of_Samples,
+    Pickup_Time,
+    Pickup_Time_2,
+    Email_Receive_Datetime,
+    Last_Update_Datetime,
+    Scan_Time,
+    Client_ID,
+    Scan_User,
+    Scanned_Number,
+    Shipment_Type
+)
+SELECT
+    Row_ID,
+    Client,
+    Tracking_Number,
+    Status,
+    Email_ID,
+    Order_Number,
+    Ship_Date,
+    Lab,
+    Weight,
+    Number_Of_Samples,
+    Pickup_Time,
+    Pickup_Time_2,
+    Email_Receive_Datetime,
+    Last_Update_Datetime,
+    Scan_Time,
+    Client_ID,
+    Scan_User,
+    Scanned_Number,
+    Shipment_Type
+FROM dbo.Inbound_Shipments;
+
+SELECT @@ROWCOUNT AS RowsBackedUp;

--- a/maintenance/duplicate-tracking-numbers-detection.sql
+++ b/maintenance/duplicate-tracking-numbers-detection.sql
@@ -1,0 +1,34 @@
+-- Duplication detection: finds Inbound_Shipments rows with the same Tracking_Number
+-- for a single Client (excludes 'N/A'). Returns up to 1000 rows, ordered by newest duplicate set first.
+WITH DuplicateTrackingNumbers AS (
+    SELECT [Tracking_Number], MAX([Row_ID]) AS MaxRowId
+    FROM [dbo].[Inbound_Shipments]
+    WHERE [Tracking_Number] <> 'N/A'
+    GROUP BY [Tracking_Number]
+    HAVING COUNT(*) > 1
+       AND COUNT(DISTINCT [Client]) = 1
+)
+SELECT TOP (1000)
+    s.[Row_ID],
+    s.[Client],
+    s.[Tracking_Number],
+    s.[Status],
+    s.[Email_ID],
+    s.[Order_Number],
+    s.[Ship_Date],
+    s.[Lab],
+    s.[Weight],
+    s.[Number_Of_Samples],
+    s.[Pickup_Time],
+    s.[Pickup_Time_2],
+    s.[Email_Receive_Datetime],
+    s.[Last_Update_Datetime],
+    s.[Scan_Time],
+    s.[Client_ID],
+    s.[Scan_User],
+    s.[Scanned_Number],
+    s.[Shipment_Type]
+FROM [dbo].[Inbound_Shipments] s
+INNER JOIN DuplicateTrackingNumbers d ON s.[Tracking_Number] = d.[Tracking_Number]
+WHERE s.[Tracking_Number] <> 'N/A'
+ORDER BY d.MaxRowId DESC, s.[Row_ID] DESC;

--- a/maintenance/remove-inbound-shipments-duplicates.sql
+++ b/maintenance/remove-inbound-shipments-duplicates.sql
@@ -1,0 +1,32 @@
+-- Remove duplicate rows from Inbound_Shipments.
+-- Uniqueness: (Tracking_Number, Client). Keeps the row with the highest Row_ID per group, deletes the rest.
+-- Run a backup first (e.g. maintenance/backup-inbound-shipments.sql) if you may need to restore.
+
+SET NOCOUNT ON;
+
+-- Preview: how many duplicate rows will be removed (optional; comment out after review)
+SELECT COUNT(*) AS RowsToDelete
+FROM (
+    SELECT Row_ID,
+           ROW_NUMBER() OVER (PARTITION BY Tracking_Number, Client ORDER BY Row_ID DESC) AS rn
+    FROM dbo.Inbound_Shipments
+) x
+WHERE rn > 1;
+
+BEGIN TRANSACTION;
+
+;WITH Ranked AS (
+    SELECT Row_ID,
+           ROW_NUMBER() OVER (PARTITION BY Tracking_Number, Client ORDER BY Row_ID DESC) AS rn
+    FROM dbo.Inbound_Shipments
+)
+DELETE s
+FROM dbo.Inbound_Shipments s
+INNER JOIN Ranked r ON s.Row_ID = r.Row_ID
+WHERE r.rn > 1;
+
+SELECT @@ROWCOUNT AS RowsDeleted;
+
+-- Review result; then either COMMIT TRANSACTION or ROLLBACK TRANSACTION
+-- COMMIT TRANSACTION;
+ROLLBACK TRANSACTION;

--- a/packageintake/src/main/resources/db/migration/V14__Add_Unique_Constraint_Inbound_Shipments_Tracking_Number_Client.sql
+++ b/packageintake/src/main/resources/db/migration/V14__Add_Unique_Constraint_Inbound_Shipments_Tracking_Number_Client.sql
@@ -1,0 +1,12 @@
+-- Enforce uniqueness on (Tracking_Number, Client) for Inbound_Shipments.
+-- Remove existing duplicates first (e.g. maintenance/remove-inbound-shipments-duplicates.sql) or this migration will fail.
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = 'UK_Inbound_Shipments_Tracking_Number_Client'
+      AND parent_object_id = OBJECT_ID('Inbound_Shipments')
+)
+BEGIN
+    ALTER TABLE Inbound_Shipments
+    ADD CONSTRAINT UK_Inbound_Shipments_Tracking_Number_Client UNIQUE (Tracking_Number, Client);
+END


### PR DESCRIPTION
## Summary
- **maintenance/** scripts for Inbound_Shipments:
  - `backup-inbound-shipments.sql` – backup table with same schema (no FKs)
  - `duplicate-tracking-numbers-detection.sql` – find duplicate (Tracking_Number, Client) rows
  - `remove-inbound-shipments-duplicates.sql` – delete duplicates, keep latest Row_ID per (Tracking_Number, Client)
- **Flyway V14** – unique constraint `UK_Inbound_Shipments_Tracking_Number_Client` on `(Tracking_Number, Client)`

Run the remove-duplicates script (and commit) before applying V14 in each environment.

Made with [Cursor](https://cursor.com)