### PR TITLE
Handle duplicates: dated backup, keep scan row, V14 index-safe, test data

### DIFF
--- a/maintenance/backup-inbound-shipments.sql
+++ b/maintenance/backup-inbound-shipments.sql
@@ -1,15 +1,20 @@
 -- Backup Inbound_Shipments to a backup table (same schema as of migrations V2–V8).
+-- Backup table name includes current date: Inbound_Shipments_Backup_yyyyMMdd (e.g. Inbound_Shipments_Backup_20260310).
 -- Backup table has no foreign keys or IDENTITY so it can be populated from a SELECT.
--- Run as needed; drop the backup table first if you want to replace a previous backup.
+-- Run as needed; each run creates a new dated backup table.
 
 SET NOCOUNT ON;
 
--- Drop existing backup table if it exists (SQL Server 2016+)
-IF OBJECT_ID(N'dbo.Inbound_Shipments_Backup', N'U') IS NOT NULL
-    DROP TABLE dbo.Inbound_Shipments_Backup;
+DECLARE @BackupTableName NVARCHAR(128) = N'Inbound_Shipments_Backup_' + CONVERT(NVARCHAR(8), GETDATE(), 112);
+DECLARE @Sql NVARCHAR(MAX);
+
+-- Drop existing backup table for today if it exists (so script is re-runnable same day)
+SET @Sql = N'IF OBJECT_ID(N''dbo.' + REPLACE(@BackupTableName, N'''', N'''''') + N''', N''U'') IS NOT NULL DROP TABLE dbo.[' + @BackupTableName + N'];';
+EXEC sp_executesql @Sql;
 
 -- Create backup table: same columns as Inbound_Shipments, no FKs, Row_ID not IDENTITY
-CREATE TABLE dbo.Inbound_Shipments_Backup (
+SET @Sql = N'
+CREATE TABLE dbo.[' + @BackupTableName + N'] (
     Row_ID                BIGINT          NOT NULL,
     Client                NVARCHAR(MAX)   NULL,
     Tracking_Number       NVARCHAR(MAX)   NULL,
@@ -29,51 +34,24 @@ CREATE TABLE dbo.Inbound_Shipments_Backup (
     Scan_User             NVARCHAR(MAX)   NULL,
     Scanned_Number        NVARCHAR(255)   NULL,
     Shipment_Type         BIGINT          NULL,
-    CONSTRAINT PK_Inbound_Shipments_Backup PRIMARY KEY (Row_ID)
-);
+    CONSTRAINT [PK_' + @BackupTableName + N'] PRIMARY KEY (Row_ID)
+);';
+EXEC sp_executesql @Sql;
 
 -- Copy all rows from Inbound_Shipments
-INSERT INTO dbo.Inbound_Shipments_Backup (
-    Row_ID,
-    Client,
-    Tracking_Number,
-    Status,
-    Email_ID,
-    Order_Number,
-    Ship_Date,
-    Lab,
-    Weight,
-    Number_Of_Samples,
-    Pickup_Time,
-    Pickup_Time_2,
-    Email_Receive_Datetime,
-    Last_Update_Datetime,
-    Scan_Time,
-    Client_ID,
-    Scan_User,
-    Scanned_Number,
-    Shipment_Type
+SET @Sql = N'
+INSERT INTO dbo.[' + @BackupTableName + N'] (
+    Row_ID, Client, Tracking_Number, Status, Email_ID, Order_Number, Ship_Date,
+    Lab, Weight, Number_Of_Samples, Pickup_Time, Pickup_Time_2,
+    Email_Receive_Datetime, Last_Update_Datetime, Scan_Time, Client_ID,
+    Scan_User, Scanned_Number, Shipment_Type
 )
 SELECT
-    Row_ID,
-    Client,
-    Tracking_Number,
-    Status,
-    Email_ID,
-    Order_Number,
-    Ship_Date,
-    Lab,
-    Weight,
-    Number_Of_Samples,
-    Pickup_Time,
-    Pickup_Time_2,
-    Email_Receive_Datetime,
-    Last_Update_Datetime,
-    Scan_Time,
-    Client_ID,
-    Scan_User,
-    Scanned_Number,
-    Shipment_Type
-FROM dbo.Inbound_Shipments;
+    Row_ID, Client, Tracking_Number, Status, Email_ID, Order_Number, Ship_Date,
+    Lab, Weight, Number_Of_Samples, Pickup_Time, Pickup_Time_2,
+    Email_Receive_Datetime, Last_Update_Datetime, Scan_Time, Client_ID,
+    Scan_User, Scanned_Number, Shipment_Type
+FROM dbo.Inbound_Shipments;';
+EXEC sp_executesql @Sql;
 
-SELECT @@ROWCOUNT AS RowsBackedUp;
+SELECT @BackupTableName AS BackupTable, @@ROWCOUNT AS RowsBackedUp;

--- a/maintenance/remove-inbound-shipments-duplicates.sql
+++ b/maintenance/remove-inbound-shipments-duplicates.sql
@@ -1,14 +1,21 @@
 -- Remove duplicate rows from Inbound_Shipments.
--- Uniqueness: (Tracking_Number, Client). Keeps the row with the highest Row_ID per group, deletes the rest.
+-- Uniqueness: (Tracking_Number, Client).
+-- Keeps one row per group: prefer rows that have Scan_Time or Scan_User; then highest Row_ID wins.
 -- Run a backup first (e.g. maintenance/backup-inbound-shipments.sql) if you may need to restore.
 
 SET NOCOUNT ON;
 
--- Preview: how many duplicate rows will be removed (optional; comment out after review)
+-- Order: 1) has scan info (Scan_Time or Scan_User), 2) highest Row_ID
+-- (1 = has Scan_Time or non-null/non-empty Scan_User; 0 = no scan info)
 SELECT COUNT(*) AS RowsToDelete
 FROM (
     SELECT Row_ID,
-           ROW_NUMBER() OVER (PARTITION BY Tracking_Number, Client ORDER BY Row_ID DESC) AS rn
+           ROW_NUMBER() OVER (
+               PARTITION BY Tracking_Number, Client
+               ORDER BY
+                   CASE WHEN Scan_Time IS NOT NULL OR (Scan_User IS NOT NULL AND LTRIM(RTRIM(Scan_User)) <> '') THEN 1 ELSE 0 END DESC,
+                   Row_ID DESC
+           ) AS rn
     FROM dbo.Inbound_Shipments
 ) x
 WHERE rn > 1;
@@ -17,7 +24,12 @@ BEGIN TRANSACTION;
 
 ;WITH Ranked AS (
     SELECT Row_ID,
-           ROW_NUMBER() OVER (PARTITION BY Tracking_Number, Client ORDER BY Row_ID DESC) AS rn
+           ROW_NUMBER() OVER (
+               PARTITION BY Tracking_Number, Client
+               ORDER BY
+                   CASE WHEN Scan_Time IS NOT NULL OR (Scan_User IS NOT NULL AND LTRIM(RTRIM(Scan_User)) <> '') THEN 1 ELSE 0 END DESC,
+                   Row_ID DESC
+           ) AS rn
     FROM dbo.Inbound_Shipments
 )
 DELETE s

--- a/maintenance/test-duplicate-inserts-and-cleanup.sql
+++ b/maintenance/test-duplicate-inserts-and-cleanup.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- Test data for duplicate (Tracking_Number, Client) handling and cleanup
+-- =============================================================================
+-- Run the INSERT block to add test rows, then run duplicate detection/removal
+-- and unique-constraint migration as needed. Run the DELETE block to remove
+-- all test data when done.
+-- Uses Client = 'TEST_DUPLICATE_CLEANUP' and Tracking_Number = 'TEST_TN_99999'
+-- so cleanup is safe and targeted.
+-- =============================================================================
+
+SET NOCOUNT ON;
+
+-- -----------------------------------------------------------------------------
+-- INSERTS: 3 rows with same (Tracking_Number, Client) to test duplicate logic
+-- Row 1: no scan info (should be removed by duplicate-removal script)
+-- Row 2: no scan info (should be removed)
+-- Row 3: has Scan_Time and Scan_User (should be KEPT by duplicate-removal script)
+-- Trigger will set Client_ID from Client.
+-- -----------------------------------------------------------------------------
+INSERT INTO dbo.Inbound_Shipments (
+    Client,
+    Tracking_Number,
+    Status,
+    Email_ID,
+    Order_Number,
+    Ship_Date,
+    Lab,
+    Weight,
+    Number_Of_Samples,
+    Pickup_Time,
+    Pickup_Time_2,
+    Email_Receive_Datetime,
+    Last_Update_Datetime,
+    Scan_Time,
+    Scan_User,
+    Scanned_Number,
+    Shipment_Type
+)
+VALUES
+    (
+        'TEST_DUPLICATE_CLEANUP',
+        'TEST_TN_99999',
+        'Pending',
+        NULL,
+        NULL,
+        CAST(GETDATE() AS DATE),
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        GETDATE(),
+        GETDATE(),
+        NULL,   -- no scan
+        NULL,   -- no scan user
+        NULL,
+        NULL
+    ),
+    (
+        'TEST_DUPLICATE_CLEANUP',
+        'TEST_TN_99999',
+        'Pending',
+        NULL,
+        NULL,
+        CAST(GETDATE() AS DATE),
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        GETDATE(),
+        GETDATE(),
+        NULL,
+        NULL,
+        NULL,
+        NULL
+    ),
+    (
+        'TEST_DUPLICATE_CLEANUP',
+        'TEST_TN_99999',
+        'Scanned',
+        NULL,
+        NULL,
+        CAST(GETDATE() AS DATE),
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        GETDATE(),
+        GETDATE(),
+        GETDATE(),              -- has scan time
+        'TEST_SCAN_USER',       -- has scan user (this row should be kept)
+        NULL,
+        NULL
+    );
+
+SELECT @@ROWCOUNT AS TestRowsInserted;
+
+-- -----------------------------------------------------------------------------
+-- CLEANUP: Remove test rows and the test client (run when done testing)
+-- -----------------------------------------------------------------------------
+/*
+DELETE FROM dbo.Inbound_Shipments
+WHERE Client = 'TEST_DUPLICATE_CLEANUP'
+   OR Tracking_Number = 'TEST_TN_99999';
+
+DELETE FROM dbo.Inbound_Shipments_Clients
+WHERE Client = 'TEST_DUPLICATE_CLEANUP';
+
+SELECT @@ROWCOUNT AS RowsDeleted;
+*/

--- a/packageintake/src/main/resources/db/migration/V14__Add_Unique_Constraint_Inbound_Shipments_Tracking_Number_Client.sql
+++ b/packageintake/src/main/resources/db/migration/V14__Add_Unique_Constraint_Inbound_Shipments_Tracking_Number_Client.sql
@@ -1,5 +1,35 @@
 -- Enforce uniqueness on (Tracking_Number, Client) for Inbound_Shipments.
 -- Remove existing duplicates first (e.g. maintenance/remove-inbound-shipments-duplicates.sql) or this migration will fail.
+-- Index key columns cannot be (N)VARCHAR(MAX); alter to bounded length. Drop dependent indexes first, then recreate. Safe to run again.
+
+-- Drop indexes that depend on Tracking_Number (block ALTER COLUMN)
+IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Inbound_Shipments_Tracking_Number' AND object_id = OBJECT_ID('Inbound_Shipments'))
+    DROP INDEX IX_Inbound_Shipments_Tracking_Number ON Inbound_Shipments;
+
+IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Inbound_Shipments_Client_ID_Tracking_Number' AND object_id = OBJECT_ID('Inbound_Shipments'))
+    DROP INDEX IX_Inbound_Shipments_Client_ID_Tracking_Number ON Inbound_Shipments;
+
+-- Alter columns to bounded length so they can be used in unique index
+ALTER TABLE Inbound_Shipments
+ALTER COLUMN Client NVARCHAR(255) NULL;
+
+ALTER TABLE Inbound_Shipments
+ALTER COLUMN Tracking_Number NVARCHAR(255) NULL;
+
+-- Recreate dropped indexes
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Inbound_Shipments_Tracking_Number' AND object_id = OBJECT_ID('Inbound_Shipments'))
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_Inbound_Shipments_Tracking_Number
+    ON Inbound_Shipments (Tracking_Number)
+    WHERE Tracking_Number IS NOT NULL;
+END
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Inbound_Shipments_Client_ID_Tracking_Number' AND object_id = OBJECT_ID('Inbound_Shipments'))
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_Inbound_Shipments_Client_ID_Tracking_Number
+    ON Inbound_Shipments (Client_ID, Tracking_Number)
+    WHERE Client_ID IS NOT NULL AND Tracking_Number IS NOT NULL AND Tracking_Number <> '';
+END
 
 IF NOT EXISTS (
     SELECT 1 FROM sys.key_constraints


### PR DESCRIPTION
## Summary
- **backup-inbound-shipments.sql**: Backup table name includes date (e.g. Inbound_Shipments_Backup_20260310) so you can see when the backup was made.
- **remove-inbound-shipments-duplicates.sql**: When deduplicating by (Tracking_Number, Client), keep the row that has Scan_Time or Scan_User; tiebreak by highest Row_ID.
- **V14 migration**: Drop indexes that depend on Tracking_Number before ALTER COLUMN, alter Client and Tracking_Number to NVARCHAR(255), recreate indexes, then add unique constraint. Idempotent.
- **test-duplicate-inserts-and-cleanup.sql**: INSERTs (3 test rows, same Tracking_Number+Client, one with scan info) and commented DELETEs to clean up after testing.

Made with [Cursor](https://cursor.com)