### PR TITLE
Add V15: default Last_Update_Datetime to GETDATE()

### DIFF
--- a/packageintake/src/main/resources/db/migration/V15__Add_Default_Last_Update_Datetime.sql
+++ b/packageintake/src/main/resources/db/migration/V15__Add_Default_Last_Update_Datetime.sql
@@ -1,0 +1,28 @@
+-- Set Last_Update_Datetime to default to current time when not specified.
+-- Backfill existing NULLs. Safe to run again (constraint added only if missing).
+
+DECLARE @ConstraintName sysname;
+
+-- Inbound_Shipments
+SET @ConstraintName = N'DF_Inbound_Shipments_Last_Update_Datetime';
+IF NOT EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = @ConstraintName)
+BEGIN
+    ALTER TABLE Inbound_Shipments
+    ADD CONSTRAINT DF_Inbound_Shipments_Last_Update_Datetime DEFAULT (GETDATE()) FOR Last_Update_Datetime;
+END
+
+UPDATE Inbound_Shipments
+SET Last_Update_Datetime = GETDATE()
+WHERE Last_Update_Datetime IS NULL;
+
+-- Inbound_Shipments_Clients
+SET @ConstraintName = N'DF_Inbound_Shipments_Clients_Last_Update_Datetime';
+IF NOT EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = @ConstraintName)
+BEGIN
+    ALTER TABLE Inbound_Shipments_Clients
+    ADD CONSTRAINT DF_Inbound_Shipments_Clients_Last_Update_Datetime DEFAULT (GETDATE()) FOR Last_Update_Datetime;
+END
+
+UPDATE Inbound_Shipments_Clients
+SET Last_Update_Datetime = GETDATE()
+WHERE Last_Update_Datetime IS NULL;


### PR DESCRIPTION
Adds Flyway migration V15: default Last_Update_Datetime to current time when not set, for Inbound_Shipments and Inbound_Shipments_Clients. Backfills existing NULLs. Idempotent (variable-based constraint check).

Made with [Cursor](https://cursor.com)